### PR TITLE
(swimm-docs) Testing Frameworks Used in the Swimmio/OpenTTD-copilot-demo Repository

### DIFF
--- a/.swm/using-catch2-testing-framework-in-openttd-copilot-demo.2t3pbr5s.sw.md
+++ b/.swm/using-catch2-testing-framework-in-openttd-copilot-demo.2t3pbr5s.sw.md
@@ -1,0 +1,2 @@
+# AI Generated document placeholder
+Powered by Swimm AI 🌊✨

--- a/.swm/using-catch2-testing-framework-in-openttd-copilot-demo.2t3pbr5s.sw.md
+++ b/.swm/using-catch2-testing-framework-in-openttd-copilot-demo.2t3pbr5s.sw.md
@@ -1,2 +1,47 @@
-# AI Generated document placeholder
-Powered by Swimm AI 🌊✨
+---
+title: Testing Frameworks Used in the Swimmio/OpenTTD-copilot-demo Repository
+---
+# Testing Frameworks Used in the Swimmio/OpenTTD-copilot-demo Repository
+
+## Intro
+
+This document provides an overview of the testing frameworks used in the `Swimmio/OpenTTD-copilot-demo` repository. The information presented here is based on a chat discussion about the repository.
+
+## Testing Framework
+
+The repository utilizes the Catch2 testing framework. This framework is used in multiple test files to ensure the reliability and correctness of the code.
+
+### Example Usage
+
+You can find examples of Catch2 usage in the following test files:
+
+- <SwmPath repo-id="Z2l0aHViJTNBJTNBT3BlblRURC1jb3BpbG90LWRlbW8lM0ElM0Fzd2ltbWlv" repo-name="OpenTTD-copilot-demo" path="src/tests/bitmath_func.cpp">`(OpenTTD-copilot-demo) src/tests/bitmath_func.cpp`</SwmPath>
+- <SwmPath repo-id="Z2l0aHViJTNBJTNBT3BlblRURC1jb3BpbG90LWRlbW8lM0ElM0Fzd2ltbWlv" repo-name="OpenTTD-copilot-demo" path="src/tests/string_func.cpp">`(OpenTTD-copilot-demo) src/tests/string_func.cpp`</SwmPath>
+
+Below is a sample code snippet demonstrating how Catch2 is included and utilized in the repository:
+
+<SwmSnippet path=".swm/the-parserrefimpl-class.fy9fq.sw.md" line="54" repo-id="Z2l0aHViJTNBJTNBT3BlblRURC1jb3BpbG90LWRlbW8lM0ElM0Fzd2ltbWlv" repo-name="OpenTTD-copilot-demo">
+
+---
+
+&nbsp;
+
+````cpp
+The constructor `ParserRefImpl(ParserBase& `<SwmToken path="src/3rdparty/catch2/catch.hpp" pos="9221:3:3" line-data="    struct Parser;">`Parser`</SwmToken>`)` initializes the <SwmToken path="src/3rdparty/catch2/catch.hpp" pos="9128:4:4" line-data="        T &amp;m_ref;">`m_ref`</SwmToken> variable with the provided <SwmToken path="src/3rdparty/catch2/catch.hpp" pos="9223:3:3" line-data="    class ParserBase {">`ParserBase`</SwmToken> reference.
+
+```c++
+            "wrap the expression inside parentheses, or decompose it");
+        }
+````
+
+---
+
+</SwmSnippet>
+
+For more information and additional examples, you can explore the repository.
+
+## Summary
+
+The `Swimmio/OpenTTD-copilot-demo` repository employs the Catch2 testing framework to write and manage its tests. This document provides a brief overview and example of how Catch2 is integrated into the project.
+
+<SwmMeta version="3.0.0"><sup>Powered by [Swimm](https://app.swimm.io/)</sup></SwmMeta>


### PR DESCRIPTION
# Description

An overview of the Catch2 testing framework used in the Swimmio/OpenTTD-copilot-demo repository.

To add more insights to this doc, [open in Swimm🔗](https://app.swimm.io/repos/Z2l0aHViJTNBJTNBT3BlblRURC1jb3BpbG90LWRlbW8lM0ElM0Fzd2ltbWlv/branch/using-catch2-testing-framework-in-openttd-copilot-demo-wkbpc/docs/2t3pbr5s)

---
Have any questions? Check out [Swimm docs](https://docs.swimm.io/) and [join our Slack Community](https://swimm.io/slack).

_*This pull request was generated by Swimm AI 🌊✨_